### PR TITLE
Fix Presences.sync for 1.2

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -77,12 +77,12 @@ let initiateChat = (username) => {
   }
 
   chan.on("presence_state", state => {
-    Presence.syncState(presences, state)
+    presences = Presence.syncState(presences, state)
     render(presences)
   })
 
   chan.on("presence_diff", diff => {
-    Presence.syncDiff(presences, diff)
+    presences = Presence.syncDiff(presences, diff)
     render(presences)
   })
 


### PR DESCRIPTION
The release notes from the full Phoenix 1.2 release (https://github.com/phoenixframework/phoenix/releases/tag/v1.2.0) mention this backward incompatible change:

> Presence.syncState and Presence.syncDiff now return a copy of the state instead of mutating it

Wish I had a pipe operator...
